### PR TITLE
Feature: Add OpenAI video models and improve error handling

### DIFF
--- a/modules/imageInference.py
+++ b/modules/imageInference.py
@@ -121,6 +121,10 @@ class txt2img:
                     "min": 32,
                     "max": 128,
                 }),
+                "outputFormat": (["WEBP", "PNG", "JPEG", "SVG"], {
+                    "tooltip": "Choose the output image format.",
+                    "default": "WEBP",
+                }),
                 "batchSize": ("INT", {
                     "tooltip": "The number of images to generate in a single request.",
                     "default": 1,
@@ -218,6 +222,7 @@ class txt2img:
         useSeed = kwargs.get("useSeed", True)
         useClipSkip = kwargs.get("useClipSkip", True)
         dimensions = kwargs.get("dimensions", "Square (512x512)")
+        outputFormat = kwargs.get("outputFormat", "WEBP")
         batchSize = kwargs.get("batchSize", 1)
         
         if (maskImage is not None and seedImage is None):
@@ -230,7 +235,7 @@ class txt2img:
                 "positivePrompt": positivePrompt,
                 "model": runwareModel,
                 "outputType": "base64Data",
-                "outputFormat": rwUtils.OUTPUT_FORMAT,
+                "outputFormat": outputFormat,
                 "outputQuality": rwUtils.OUTPUT_QUALITY,
                 "numberResults": batchSize,
             }

--- a/modules/videoModelSearch.py
+++ b/modules/videoModelSearch.py
@@ -43,6 +43,10 @@ class videoModelSearch:
             "runware:200@1 (Wan 2.1 1.3B)",
             "runware:200@2 (Wan 2.1 14B)",
         ],
+        "OpenAI": [
+            "openai:3@1 (OpenAI Sora 3.1)",
+            "openai:3@0 (OpenAI Sora 3.0)",
+        ],
     }
     
     # Model dimensions mapping
@@ -88,13 +92,12 @@ class videoModelSearch:
         # Wan Models
         "runware:200@1": {"width": 853, "height": 480}, # Wan 2.1 1.3B
         "runware:200@2": {"width": 853, "height": 480}, # Wan 2.1 14B
+        
+        # OpenAI Models
+        "openai:3@1": {"width": 1280, "height": 720}, # OpenAI Sora 3.1
+        "openai:3@0": {"width": 1280, "height": 720}, # OpenAI Sora 3.0
     }
     
-    # Models that support seed parameter
-    SEED_SUPPORTED_MODELS = [
-        "runware:200@1",  # Wan 2.1 1.3B
-        "runware:200@2",  # Wan 2.1 14B
-    ]
     
     @classmethod
     def INPUT_TYPES(cls):
@@ -116,7 +119,8 @@ class videoModelSearch:
                         "MiniMax",
                         "PixVerse",
                         "Vidu",
-                        "Wan"
+                        "Wan",
+                        "OpenAI"
                     ], {
                     "tooltip": "Choose Video Model Architecture To Filter Results.",
                     "default": "KlingAI",


### PR DESCRIPTION
- Added OpenAI Sora 3.0 and 3.1 models to video inference (openai:3@0, openai:3@1)
- Added OpenAI architecture to video model search dropdown
- Improved video inference error handling to properly display API error messages
- Replaced hardcoded seed support with flexible useSeed parameter in video inference
- Added selectable output format (WEBP, PNG, JPEG, SVG) to image inference UI
- Updated parameter order: useSeed, seed for better UX consistency
- Removed SEED_SUPPORTED_MODELS hardcoded list for better flexibility