### PR TITLE
Add custom input structure support for sourceful models

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -23,6 +23,7 @@ from .modules.ipAdapter import ipAdapter
 from .modules.ipAdapterCombine import ipAdapterCombine
 from .modules.vaeSearch import vaeSearch
 from .modules.referenceImages import referenceImages
+from .modules.imageInferenceInputs import imageInferenceInputs
 from .modules.videoInference import txt2vid
 from .modules.videoModelSearch import videoModelSearch
 from .modules.frameImages import RunwareFrameImages
@@ -75,6 +76,7 @@ NODE_CLASS_MAPPINGS = {
     "Runware IPAdapter": ipAdapter,
     "Runware IPAdapters Combine": ipAdapterCombine,
     "Runware Reference Images": referenceImages,
+    "Runware Image Inference Inputs": imageInferenceInputs,
     "Runware Video Inference": txt2vid,
     "Runware Video Model Search": videoModelSearch,
     "Runware Frame Images": RunwareFrameImages,

--- a/clientlibs/types.js
+++ b/clientlibs/types.js
@@ -74,6 +74,7 @@ const RUNWARE_NODE_TYPES = {
     EMBEDDINGCOMBINE: "Runware Embedding Combine",
     VAE: "Runware VAE Search",
     REFERENCEIMAGES: "Runware Reference Images",
+    IMAGEINFERENCEINPUTS: "Runware Image Inference Inputs",
     VIDEOINFERENCE: "Runware Video Inference",
     VIDEOMODELSEARCH: "Runware Video Model Search",
     FRAMEIMAGES: "Runware Frame Images",

--- a/modules/imageInference.py
+++ b/modules/imageInference.py
@@ -166,6 +166,9 @@ class txt2img:
                 "referenceImages": ("RUNWAREREFERENCEIMAGES", {
                     "tooltip": "Connect a Runware Reference Images Node to provide visual guidance for image generation.",
                 }),
+                "inputs": ("RUNWAREIMAGEINFERENCEINPUTS", {
+                    "tooltip": "Connect a Runware Image Inference Inputs Node to provide custom inputs like references for the inference process.",
+                }),
                 "providerSettings": ("RUNWAREPROVIDERSETTINGS", {
                     "tooltip": "Connect a Runware Provider Settings Node to configure provider-specific parameters.",
                 }),
@@ -203,6 +206,7 @@ class txt2img:
         runwareEmbedding = kwargs.get("Embeddings", None)
         runwareVAE = kwargs.get("VAE", None)
         referenceImages = kwargs.get("referenceImages", None)
+        inputs = kwargs.get("inputs", None)
         providerSettings = kwargs.get("providerSettings", None)
         seedImage = kwargs.get("seedImage", None)
         seedImageStrength = kwargs.get("strength", 0.8)
@@ -303,11 +307,11 @@ class txt2img:
 
         # Handle referenceImages
         if referenceImages is not None:
-            # Check if model is sourceful - use different structure
-            if runwareModel.startswith("sourceful"):
-                genConfig[0]["inputs"] = {"references": referenceImages}
-            else:
-                genConfig[0]["referenceImages"] = referenceImages
+            genConfig[0]["referenceImages"] = referenceImages
+
+        # Handle inputs (custom inference inputs)
+        if inputs is not None:
+            genConfig[0]["inputs"] = inputs
 
         # Handle providerSettings - extract provider name from model and merge with custom settings
         if providerSettings is not None:

--- a/modules/imageInference.py
+++ b/modules/imageInference.py
@@ -303,7 +303,11 @@ class txt2img:
 
         # Handle referenceImages
         if referenceImages is not None:
-            genConfig[0]["referenceImages"] = referenceImages
+            # Check if model is sourceful - use different structure
+            if runwareModel.startswith("sourceful"):
+                genConfig[0]["inputs"] = {"references": referenceImages}
+            else:
+                genConfig[0]["referenceImages"] = referenceImages
 
         # Handle providerSettings - extract provider name from model and merge with custom settings
         if providerSettings is not None:

--- a/modules/imageInferenceInputs.py
+++ b/modules/imageInferenceInputs.py
@@ -1,0 +1,54 @@
+from .utils import runwareUtils as rwUtils
+
+class imageInferenceInputs:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {},
+            "optional": {
+                "Reference Image 1": ("IMAGE", {
+                    "tooltip": "Specifies Reference Image 1 for the inputs. These reference images help guide the image generation process."
+                }),
+                "Reference Image 2": ("IMAGE", {
+                    "tooltip": "Specifies Reference Image 2 for the inputs. These reference images help guide the image generation process."
+                }),
+                "Reference Image 3": ("IMAGE", {
+                    "tooltip": "Specifies Reference Image 3 for the inputs. These reference images help guide the image generation process."
+                }),
+                "Reference Image 4": ("IMAGE", {
+                    "tooltip": "Specifies Reference Image 4 for the inputs. These reference images help guide the image generation process."
+                }),
+            }
+        }
+
+    DESCRIPTION = "Configure custom inputs for Runware Image Inference, including reference images that can be passed to the inference node."
+    FUNCTION = "createInputs"
+    RETURN_TYPES = ("RUNWAREIMAGEINFERENCEINPUTS",)
+    RETURN_NAMES = ("Inference Inputs",)
+    CATEGORY = "Runware"
+
+    def createInputs(self, **kwargs):
+        refImage1 = kwargs.get("Reference Image 1", None)
+        refImage2 = kwargs.get("Reference Image 2", None)
+        refImage3 = kwargs.get("Reference Image 3", None)
+        refImage4 = kwargs.get("Reference Image 4", None)
+
+        # Build the inputs structure
+        inputs = {}
+        
+        # Handle references if any are provided
+        references = []
+        if refImage1 is not None:
+            references.append(rwUtils.convertTensor2IMG(refImage1))
+        if refImage2 is not None:
+            references.append(rwUtils.convertTensor2IMG(refImage2))
+        if refImage3 is not None:
+            references.append(rwUtils.convertTensor2IMG(refImage3))
+        if refImage4 is not None:
+            references.append(rwUtils.convertTensor2IMG(refImage4))
+        
+        if len(references) > 0:
+            inputs["references"] = references
+
+        return (inputs, )
+


### PR DESCRIPTION
- Added check to detect sourceful models by AIR code prefix
- When model starts with 'sourceful', use inputs.references structure
- Maintains backward compatibility with referenceImages for other models
- Supports new API format: inputs: {references: [image_urls]}