### PR TITLE
fix: Change inputImage to image in videoInputsFrame

### DIFF
--- a/modules/videoInputsFrame.py
+++ b/modules/videoInputsFrame.py
@@ -50,7 +50,7 @@ class RunwareVideoInputsFrameImages:
     
     def _createFrameEntry(self, image, frameLabel):
         imageData = rwUtils.convertTensor2IMGBase64Only(image)
-        entry = {"inputImage": imageData}
+        entry = {"image": imageData}
         
         if isinstance(frameLabel, str) and frameLabel.strip() != "":
             if frameLabel.strip().isdigit():


### PR DESCRIPTION
- Update key from 'inputImage' to 'image' in frame entry creation
- Ensure consistency with video frame image API format